### PR TITLE
ATF 2.0

### DIFF
--- a/conf/machine/orange-pi-pc-plus.conf
+++ b/conf/machine/orange-pi-pc-plus.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2017.03%"
+PREFERRED_VERSION_u-boot = "v2018.03%"
 
 KERNEL_DEVICETREE = "sun8i-h3-orangepi-pc-plus.dtb"
 UBOOT_MACHINE = "orangepi_pc_plus_defconfig"

--- a/recipes-bsp/atf/atf-sunxi_git.bb
+++ b/recipes-bsp/atf/atf-sunxi_git.bb
@@ -1,16 +1,16 @@
 DESCRIPTION = "ARM Trusted Firmware Allwinner"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://license.md;md5=829bdeb34c1d9044f393d5a16c068371"
+LIC_FILES_CHKSUM = "file://license.rst;md5=e927e02bca647e14efd87e9e914b2443"
 
-SRC_URI = "git://github.com/apritzel/arm-trusted-firmware;nobranch=1"
-SRCREV = "aa75c8da415158a94b82a430b2b40000778e851f"
+SRC_URI = "git://github.com/Andre-ARM/arm-trusted-firmware;branch=allwinner/pmic-v2"
+SRCREV = "7db0c96023281d8a530f5e011a232e5d56557437"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 
 COMPATIBLE_MACHINE = "(sun50i)"
 
-PLATFORM_sun50i = "sun50iw1p1"
+PLATFORM_sun50i = "sun50i_a64"
 
 LDFLAGS[unexport] = "1"
 
@@ -18,10 +18,10 @@ do_compile() {
     oe_runmake -C ${S} BUILD_BASE=${B} \
       CROSS_COMPILE=${TARGET_PREFIX} \
       PLAT=${PLATFORM} \
-      bl31 \
-      all
+      DEBUG=1 \
+      bl31
 }
 
 do_install() {
-    install -D -p -m 0644 ${B}/${PLATFORM}/release/bl31.bin ${DEPLOY_DIR_IMAGE}/bl31.bin
+    install -D -p -m 0644 ${B}/${PLATFORM}/debug/bl31.bin ${DEPLOY_DIR_IMAGE}/bl31.bin
 }

--- a/recipes-bsp/u-boot/files/0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch
+++ b/recipes-bsp/u-boot/files/0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch
@@ -1,0 +1,26 @@
+From f4a77da23b3890b53efab6a927cbe99b76ef3b26 Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@resin.io>
+Date: Wed, 12 Sep 2018 14:22:49 +0200
+Subject: [PATCH] nanopi_neo_air_defconfig: Enable eMMC support
+
+Upstream-status: Pending
+Signed-off-by: Florin Sarbu <florin@resin.io>
+---
+ configs/nanopi_neo_air_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/nanopi_neo_air_defconfig b/configs/nanopi_neo_air_defconfig
+index ca9c2dd..74ce044 100644
+--- a/configs/nanopi_neo_air_defconfig
++++ b/configs/nanopi_neo_air_defconfig
+@@ -10,6 +10,7 @@ CONFIG_DEFAULT_DEVICE_TREE="sun8i-h3-nanopi-neo-air"
+ # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
+ CONFIG_CONSOLE_MUX=y
+ CONFIG_SPL=y
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
+ # CONFIG_CMD_FLASH is not set
+ # CONFIG_SPL_DOS_PARTITION is not set
+ # CONFIG_SPL_ISO_PARTITION is not set
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot_2018.03.bb
+++ b/recipes-bsp/u-boot/u-boot_2018.03.bb
@@ -18,6 +18,7 @@ DEFAULT_PREFERENCE_sun50i="1"
 
 SRC_URI = "git://git.denx.de/u-boot.git;branch=master \
            file://u-boot-pylibfdt-native-build.patch \
+           file://0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch \
            file://boot.cmd \
            "
 

--- a/recipes-kernel/linux/linux-mainline/0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch
+++ b/recipes-kernel/linux/linux-mainline/0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch
@@ -9,18 +9,22 @@ This patch was originally submitted by Jelle van der Waa. Martin Kelly
 modified it to compile on the latest kernel, fixed up some review
 comments from Maxime Ripard, and re-tested the patch.
 
+The patch has been reworked to add back eMMC support which has been left
+out at the last backport.
+
 Cc: Maxime Ripard <maxime.ripard@free-electrons.com>
 Cc: linux-sunxi@googlegroups.com
 Cc: devicetree@vger.kernel.org
 Signed-off-by: Jelle van der Waa <jelle@vdwaa.nl>
 Signed-off-by: Martin Kelly <mkelly@xevo.com>
 Signed-off-by: Maxime Ripard <maxime.ripard@free-electrons.com>
+Signed-off-by: Florin Sarbu <florin@resin.io>
 ---
- arch/arm/boot/dts/sun8i-h3-nanopi-neo-air.dts | 24 ++++++++++++++++++++++++
- 1 file changed, 24 insertions(+)
+ arch/arm/boot/dts/sun8i-h3-nanopi-neo-air.dts | 34 +++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
 
 diff --git a/arch/arm/boot/dts/sun8i-h3-nanopi-neo-air.dts b/arch/arm/boot/dts/sun8i-h3-nanopi-neo-air.dts
-index 03ff6f8b93ff..920849092cc8 100644
+index 03ff6f8..a9331fe 100644
 --- a/arch/arm/boot/dts/sun8i-h3-nanopi-neo-air.dts
 +++ b/arch/arm/boot/dts/sun8i-h3-nanopi-neo-air.dts
 @@ -72,6 +72,11 @@
@@ -35,7 +39,7 @@ index 03ff6f8b93ff..920849092cc8 100644
  };
  
  &mmc0 {
-@@ -84,6 +89,25 @@
+@@ -84,6 +89,35 @@
  	status = "okay";
  };
  
@@ -56,6 +60,16 @@ index 03ff6f8b93ff..920849092cc8 100644
 +		interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>; /* PG10 / EINT10 */
 +		interrupt-names = "host-wake";
 +	};
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_8bit_pins>;
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	bus-width = <8>;
++	non-removable;
++	status = "okay";
 +};
 +
  &uart0 {


### PR DESCRIPTION
This is a big update for ATF. It includes a lot of stability fixes as
well as new and exciting features like a proper core offlining and
making shutdown work more reliably.

The size is drastically bigger, though. More than 1.5 times. So in order
to make it fit to U-Boot SPL we need to make some adjustments to U-Boot
proper by either storing environment on a FAT partition (as in upstream)
or moving to 8Mb offset (because of the Mender partitioning).

I also propose to use a debug build since we don't really care about
size anymore. The output is actually of help so let's enable it.

PLAT is changed to sun50i_a64 because upstream ATF has a common target
for H5 and A64 because they are mostly the same. We'll need to make a
couple of adjustments to our neutis-n5.dtsi in order to make DRAM and
eMMC regulators do the right thing. And then we'll need to patch ATF to
support these changes.