### PR TITLE
bsp: atf: add notimestamp for do_install

### DIFF
--- a/recipes-bsp/atf/atf-sunxi_git.bb
+++ b/recipes-bsp/atf/atf-sunxi_git.bb
@@ -28,3 +28,5 @@ do_compile() {
 do_install() {
     install -D -p -m 0644 ${B}/${PLATFORM}/debug/bl31.bin ${DEPLOY_DIR_IMAGE}/bl31.bin
 }
+
+do_install[nostamp] = "1"


### PR DESCRIPTION
There's no way for Yocto to know if bl31.bin has been removed. Hence we
need to actually rebuild it everytime.